### PR TITLE
chore: add postgresql to docker compose and as dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Gradle cache
+.gradle/
+build/
+
+# Specific file types if they appear elsewhere
+*.bin
+*.lock

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
+	implementation 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  app:
+    image: openjdk:17-jdk-slim
+    volumes:
+      - ./build/libs:/app/build/libs
+    working_dir: /app
+    command: java -jar /app/build/libs/mini-doodle-0.0.1-SNAPSHOT.jar
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/mydatabase
+      - SPRING_DATASOURCE_USERNAME=user
+      - SPRING_DATASOURCE_PASSWORD=password
+  db:
+    image: postgres:17.5
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=mydatabase

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=mini-doodle
+spring.datasource.url=jdbc:postgresql://localhost:5432/mydatabase
+spring.datasource.username=user
+spring.datasource.password=password
+spring.datasource.driver-class-name=org.postgresql.Driver


### PR DESCRIPTION
Generated necessary changes for having postgresql as a dependency in the spring boot project and as an image needed to run the project with docker compose

I've added patterns to `.gitignore` to exclude:
- Gradle cache directory (`.gradle/`)
- Build output directory (`build/`)
- General binary (`*.bin`) and lock (`*.lock`) files

These files are typically generated during the build process or by IDEs and should not be committed to the repository. This change helps keep your repository clean and focused on source files.